### PR TITLE
Add Async Suffix to Task returning method names.

### DIFF
--- a/YandexTranslateCSharpDemo/MainWindow.xaml.cs
+++ b/YandexTranslateCSharpDemo/MainWindow.xaml.cs
@@ -36,7 +36,7 @@ namespace YandexTranslateCSharpDemo
                 wrapper.ApiKey = apiKey;
                 try
                 {
-                    string lang = await wrapper.DetectLanguage(text1.Text);
+                    string lang = await wrapper.DetectLanguageAsync(text1.Text);
                     languagesCombo.SelectedValue = lang;
                 }
                 catch(YandexTranslateException ex)
@@ -53,7 +53,7 @@ namespace YandexTranslateCSharpDemo
                 wrapper.ApiKey = apiKey;
                 try
                 {
-                    string lang = await wrapper.DetectLanguage(text2.Text);
+                    string lang = await wrapper.DetectLanguageAsync(text2.Text);
                     languagesCombo2.SelectedValue = lang;
                 }
                 catch (YandexTranslateException ex)
@@ -88,7 +88,7 @@ namespace YandexTranslateCSharpDemo
                 string direction = languagesCombo.SelectedValue + "-" + languagesCombo2.SelectedValue;
                 try
                 {
-                    text2.Text = await wrapper.TranslateText(text1.Text, direction);
+                    text2.Text = await wrapper.TranslateTextAsync(text1.Text, direction);
                 }
                 catch (YandexTranslateException ex)
                 {
@@ -105,7 +105,7 @@ namespace YandexTranslateCSharpDemo
                 List<string> languages;
                 try
                 {
-                    languages = await wrapper.GetLanguages();
+                    languages = await wrapper.GetLanguagesAsync();
                 }
                 catch(YandexTranslateException ex)
                 {

--- a/YandexTranslateCSharpSdk/DetectLanguageManager.cs
+++ b/YandexTranslateCSharpSdk/DetectLanguageManager.cs
@@ -21,9 +21,9 @@ namespace YandexTranslateCSharpSdk
     {
         internal string ApiKey { get; set; }
 
-        internal async Task<string> DetectLanguageXml(string text)
+        internal async Task<string> DetectLanguageXmlAsync(string text)
         {
-            string response = await PostData(text, "https://translate.yandex.net/api/v1.5/tr/detect?",
+            string response = await PostDataAsync(text, "https://translate.yandex.net/api/v1.5/tr/detect?",
                "application/xml");
             XmlDocument xmlDoc = new XmlDocument();            
             xmlDoc.LoadXml(response);
@@ -35,9 +35,9 @@ namespace YandexTranslateCSharpSdk
             return null;
             
         }
-        internal async Task<string> DetectLanguageJson(string text)
+        internal async Task<string> DetectLanguageJsonAsync(string text)
         {
-            string response = await PostData(text, "https://translate.yandex.net/api/v1.5/tr.json/detect?",
+            string response = await PostDataAsync(text, "https://translate.yandex.net/api/v1.5/tr.json/detect?",
                 "application/json");
 #if NETCORE
             var dict = JsonConvert.DeserializeObject<Dictionary<string, object>>(response); 
@@ -48,7 +48,7 @@ namespace YandexTranslateCSharpSdk
             return lang == null ? null : lang.ToString();
         }
 
-        private async Task<string> PostData(string text, string url, string mediaType)
+        private async Task<string> PostDataAsync(string text, string url, string mediaType)
         {
             try
             {

--- a/YandexTranslateCSharpSdk/LanguagesManager.cs
+++ b/YandexTranslateCSharpSdk/LanguagesManager.cs
@@ -20,10 +20,10 @@ namespace YandexTranslateCSharpSdk
     {
         internal string ApiKey { get; set; }
 
-        internal async Task<List<string>> GetLanguagesXml()
+        internal async Task<List<string>> GetLanguagesXmlAsync()
         {
             List<string> languages = new List<string>();
-            string response = await PostData("https://translate.yandex.net/api/v1.5/tr/getLangs?", "application/xml");
+            string response = await PostDataAsync("https://translate.yandex.net/api/v1.5/tr/getLangs?", "application/xml");
             XmlDocument xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(response);            
             XmlNodeList list = xmlDoc.GetElementsByTagName("Item");
@@ -34,9 +34,9 @@ namespace YandexTranslateCSharpSdk
             return languages;
         }
 
-        internal async Task<List<string>> GetLanguagesJson()
+        internal async Task<List<string>> GetLanguagesJsonAsync()
         {            
-            string response = await PostData("https://translate.yandex.net/api/v1.5/tr.json/getLangs?", "application/json");
+            string response = await PostDataAsync("https://translate.yandex.net/api/v1.5/tr.json/getLangs?", "application/json");
 #if NETCORE
             var dict = JsonConvert.DeserializeObject<Dictionary<string, object>>(response);
             var lang = JsonConvert.DeserializeObject<Dictionary<string, object>>(dict["langs"].ToString());
@@ -47,7 +47,7 @@ namespace YandexTranslateCSharpSdk
             return new List<string>(lang.Keys);           
         }
 
-        private async Task<string> PostData(string url, string mediaType)
+        private async Task<string> PostDataAsync(string url, string mediaType)
         {
             try
             {

--- a/YandexTranslateCSharpSdk/TranslateManager.cs
+++ b/YandexTranslateCSharpSdk/TranslateManager.cs
@@ -22,9 +22,9 @@ namespace YandexTranslateCSharpSdk
     {
         internal string ApiKey { get; set; }
 
-        internal async Task<string> TranslateTextXml(string text, string direction)
+        internal async Task<string> TranslateTextXmlAsync(string text, string direction)
         {
-            string response = await PostData(text, direction,
+            string response = await PostDataAsync(text, direction,
                 "https://translate.yandex.net/api/v1.5/tr/translate?", "application/xml");
             XmlDocument xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(response);
@@ -35,9 +35,9 @@ namespace YandexTranslateCSharpSdk
             }
             return null;
         }
-        internal async Task<string> TranslateTextJson(string text, string direction)
+        internal async Task<string> TranslateTextJsonAsync(string text, string direction)
         {
-            string response = await PostData(text, direction,
+            string response = await PostDataAsync(text, direction,
              "https://translate.yandex.net/api/v1.5/tr.json/translate?", "application/json");
 #if NETCORE
             var dict = JsonConvert.DeserializeObject<Dictionary<string, object>>(response); 
@@ -65,7 +65,7 @@ namespace YandexTranslateCSharpSdk
             return null;
         }
 
-        private async Task<string> PostData(string text, string direction, string url, string mediaType)
+        private async Task<string> PostDataAsync(string text, string direction, string url, string mediaType)
         {
             try
             {

--- a/YandexTranslateCSharpSdk/YandexTranslateSdk.cs
+++ b/YandexTranslateCSharpSdk/YandexTranslateSdk.cs
@@ -15,9 +15,9 @@ namespace YandexTranslateCSharpSdk
 
         public string ApiKey { get; set; }
 
-        public bool IsJson { get; set; }        
+        public bool IsJson { get; set; }
 
-        public async Task<string> DetectLanguage(string text)
+        public async Task<string> DetectLanguageAsync(string text)
         {
             if (string.IsNullOrEmpty(ApiKey))
             {
@@ -26,15 +26,15 @@ namespace YandexTranslateCSharpSdk
             detectManager.ApiKey = ApiKey;
             if (IsJson)
             {
-                return await detectManager.DetectLanguageJson(text);
+                return await detectManager.DetectLanguageJsonAsync(text);
             }
             else
             {
-                return await detectManager.DetectLanguageXml(text);
+                return await detectManager.DetectLanguageXmlAsync(text);
             }
         }
 
-        public async Task<List<string>> GetLanguages()
+        public async Task<List<string>> GetLanguagesAsync()
         {
             if (string.IsNullOrEmpty(ApiKey))
             {
@@ -43,15 +43,15 @@ namespace YandexTranslateCSharpSdk
             languagesManager.ApiKey = ApiKey;
             if (IsJson)
             {
-                return await languagesManager.GetLanguagesJson();
+                return await languagesManager.GetLanguagesJsonAsync();
             }
             else
             {
-                return await languagesManager.GetLanguagesXml();
+                return await languagesManager.GetLanguagesXmlAsync();
             }
         }
 
-        public async Task<string> TranslateText(string text, string direction)
+        public async Task<string> TranslateTextAsync(string text, string direction)
         {
             if (string.IsNullOrEmpty(ApiKey))
             {
@@ -60,11 +60,11 @@ namespace YandexTranslateCSharpSdk
             translateManager.ApiKey = ApiKey;
             if (IsJson)
             {
-                return await translateManager.TranslateTextJson(text, direction);
+                return await translateManager.TranslateTextJsonAsync(text, direction);
             }
             else
             {
-                return await translateManager.TranslateTextXml(text, direction);
+                return await translateManager.TranslateTextXmlAsync(text, direction);
             }
         }
 

--- a/YandexTranslateCSharpSdkTests/YandexTranslateTests.cs
+++ b/YandexTranslateCSharpSdkTests/YandexTranslateTests.cs
@@ -39,7 +39,7 @@ namespace YandexTranslateCSharpSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = false;
-            List<string> languages = await wrapper.GetLanguages();            
+            List<string> languages = await wrapper.GetLanguagesAsync();            
             Assert.AreNotEqual(languages, null);
             Assert.IsTrue(languages.Contains("en"));
             Assert.IsTrue(languages.Contains("ru"));
@@ -51,7 +51,7 @@ namespace YandexTranslateCSharpSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = true;
-            List<string> languages = await wrapper.GetLanguages();
+            List<string> languages = await wrapper.GetLanguagesAsync();
             Assert.AreNotEqual(languages, null);
             Assert.IsTrue(languages.Contains("en"));
             Assert.IsTrue(languages.Contains("ru"));
@@ -63,7 +63,7 @@ namespace YandexTranslateCSharpSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = false;
-            string result = await wrapper.DetectLanguage("Привет");
+            string result = await wrapper.DetectLanguageAsync("Привет");
             Assert.AreEqual(result, "ru");
         }
 
@@ -73,7 +73,7 @@ namespace YandexTranslateCSharpSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = true;
-            string result = await wrapper.DetectLanguage(_randomEnglishText);
+            string result = await wrapper.DetectLanguageAsync(_randomEnglishText);
             Assert.AreEqual(result, "en");
         }
 
@@ -83,7 +83,7 @@ namespace YandexTranslateCSharpSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = false;
-            string translatedText = await wrapper.TranslateText(_randomEnglishText, "en-ru");
+            string translatedText = await wrapper.TranslateTextAsync(_randomEnglishText, "en-ru");
             Console.WriteLine(translatedText);
             Assert.IsTrue(!string.IsNullOrEmpty(translatedText));
         }
@@ -94,7 +94,7 @@ namespace YandexTranslateCSharpSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = true;
-            string translatedText = await wrapper.TranslateText(_randomEnglishText, "en-ru");
+            string translatedText = await wrapper.TranslateTextAsync(_randomEnglishText, "en-ru");
             Console.WriteLine(translatedText);
             Assert.IsTrue(!string.IsNullOrEmpty(translatedText));
         }
@@ -105,7 +105,7 @@ namespace YandexTranslateCSharpSdkTests
         {
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = "KeyNotExists";
-            List<string> languages = await wrapper.GetLanguages();
+            List<string> languages = await wrapper.GetLanguagesAsync();
         }
 
         [TestMethod]
@@ -114,7 +114,7 @@ namespace YandexTranslateCSharpSdkTests
         {
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = null;
-            List<string> languages = await wrapper.GetLanguages();
+            List<string> languages = await wrapper.GetLanguagesAsync();
         }
 
         [TestMethod]
@@ -124,7 +124,7 @@ namespace YandexTranslateCSharpSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = true;
-            string translatedText = await wrapper.TranslateText(_randomEnglishText, "BAD");            
+            string translatedText = await wrapper.TranslateTextAsync(_randomEnglishText, "BAD");            
         }
     }
 }

--- a/YandexTranslateCoreSdkDemo/Controllers/TranslateController.cs
+++ b/YandexTranslateCoreSdkDemo/Controllers/TranslateController.cs
@@ -23,10 +23,10 @@ namespace YandexTranslateCoreSdkDemo.Controllers
             {
                 YandexTranslateSdk wrapper = new YandexTranslateSdk();
                 wrapper.ApiKey = model.Key;
-                string inputLanguage = await wrapper.DetectLanguage(model.InputText);
+                string inputLanguage = await wrapper.DetectLanguageAsync(model.InputText);
                 string outputLanguage = model.OutputLanguage;
                 string direction = inputLanguage + "-" + outputLanguage;
-                model.OutputText = await wrapper.TranslateText(model.InputText, direction);
+                model.OutputText = await wrapper.TranslateTextAsync(model.InputText, direction);
                 model.Languages = new List<string>(TempData["Languages"] as string[]);
 
                 ModelState.Clear();
@@ -45,7 +45,7 @@ namespace YandexTranslateCoreSdkDemo.Controllers
             }
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = model.Key;
-            model.Languages = await wrapper.GetLanguages();
+            model.Languages = await wrapper.GetLanguagesAsync();
             TempData["Languages"] = model.Languages;
             return View("Index", model);
         }

--- a/YandexTranslateCoreSdkTests/YandexTranslateTests.cs
+++ b/YandexTranslateCoreSdkTests/YandexTranslateTests.cs
@@ -35,7 +35,7 @@ namespace YandexTranslateCoreSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = false;
-            List<string> languages = await wrapper.GetLanguages();
+            List<string> languages = await wrapper.GetLanguagesAsync();
             Assert.NotEqual(languages, null);
             Assert.True(languages.Contains("en"));
             Assert.True(languages.Contains("ru"));
@@ -47,7 +47,7 @@ namespace YandexTranslateCoreSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = true;
-            List<string> languages = await wrapper.GetLanguages();
+            List<string> languages = await wrapper.GetLanguagesAsync();
             Assert.NotEqual(languages, null);
             Assert.True(languages.Contains("en"));
             Assert.True(languages.Contains("ru"));
@@ -59,7 +59,7 @@ namespace YandexTranslateCoreSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = false;
-            string result = await wrapper.DetectLanguage("Привет");
+            string result = await wrapper.DetectLanguageAsync("Привет");
             Assert.Equal(result, "ru");
         }
 
@@ -69,7 +69,7 @@ namespace YandexTranslateCoreSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = true;
-            string result = await wrapper.DetectLanguage(_randomEnglishText);
+            string result = await wrapper.DetectLanguageAsync(_randomEnglishText);
             Assert.Equal(result, "en");
         }
 
@@ -79,7 +79,7 @@ namespace YandexTranslateCoreSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = false;
-            string translatedText = await wrapper.TranslateText(_randomEnglishText, "en-ru");
+            string translatedText = await wrapper.TranslateTextAsync(_randomEnglishText, "en-ru");
             Console.WriteLine(translatedText);
             Assert.True(!string.IsNullOrEmpty(translatedText));
         }
@@ -90,7 +90,7 @@ namespace YandexTranslateCoreSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = true;
-            string translatedText = await wrapper.TranslateText(_randomEnglishText, "en-ru");
+            string translatedText = await wrapper.TranslateTextAsync(_randomEnglishText, "en-ru");
             Console.WriteLine(translatedText);
             Assert.True(!string.IsNullOrEmpty(translatedText));
         }
@@ -100,7 +100,7 @@ namespace YandexTranslateCoreSdkTests
         {
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = "KeyNotExists";            
-            await Assert.ThrowsAsync<YandexTranslateException>(() => wrapper.GetLanguages());
+            await Assert.ThrowsAsync<YandexTranslateException>(() => wrapper.GetLanguagesAsync());
         }
 
         [Fact]        
@@ -108,7 +108,7 @@ namespace YandexTranslateCoreSdkTests
         {
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = null;
-            await Assert.ThrowsAsync<YandexTranslateException>(() => wrapper.GetLanguages());
+            await Assert.ThrowsAsync<YandexTranslateException>(() => wrapper.GetLanguagesAsync());
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace YandexTranslateCoreSdkTests
             YandexTranslateSdk wrapper = new YandexTranslateSdk();
             wrapper.ApiKey = _apiKey;
             wrapper.IsJson = true;
-            await Assert.ThrowsAsync<YandexTranslateException>(() => wrapper.TranslateText(_randomEnglishText, "BAD"));            
+            await Assert.ThrowsAsync<YandexTranslateException>(() => wrapper.TranslateTextAsync(_randomEnglishText, "BAD"));            
         }
     }
 }


### PR DESCRIPTION
Fixes #18 

This Pull Request add the Async suffix to all Task returning methods in the YandexTranslate library only.

It does not cover the method names found in both Demo's and the Test project as that is outside of the scope of this PR. 

Fits TAP documentation as seen here: 
https://docs.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap